### PR TITLE
Disable response login required for views and bump version

### DIFF
--- a/incidentresponse/settings/base.py
+++ b/incidentresponse/settings/base.py
@@ -121,9 +121,11 @@ REST_FRAMEWORK = {
     # Use Django's standard `django.contrib.auth` permissions,
     # or allow read-only access for unauthenticated users.
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.IsAuthenticated'
+        'rest_framework.permissions.IsAuthenticatedOrReadOnly'
     ]
 }
+
+RESPONSE_LOGIN_REQUIRED = False
 
 # Markdown Filter
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Django==2.2.4
 psycopg2-binary==2.8.2
-django-incident-response==0.1.7
+django-incident-response==0.1.14
 python-dotenv==0.10.3


### PR DESCRIPTION
For the productionising of Response, Setting `RESPONSE_LOGIN_REQUIRED` to false, as we want everyone to be able to see incidents. Also set the Django setting to `IsAuthenticatedOrReadOnly` too.

While here, bumped the version of Response too.